### PR TITLE
do not create sam.cr file on install if it already exists

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,4 +9,4 @@ crystal: 0.30.1
 license: MIT
 
 scripts:
-  postinstall: "false | cp -i examples/sam.template ../../sam.cr 2>/dev/null"
+  postinstall: "false | [ -f ../../sam.cr ]  && true || cp -i examples/sam.template ../../sam.cr 2>/dev/null"

--- a/spec/task_spec.cr
+++ b/spec/task_spec.cr
@@ -38,7 +38,7 @@ describe Sam::Task do
 
       it "raises exception and not invokes if dependency raise exception" do
         arr = [] of Int32
-        namespace.task("t2") { 1 / 0 }
+        namespace.task("t2") { 1 // 0 }
         t = namespace.task("t3", ["t2"]) { arr << 3 }
         expect_raises(DivisionByZeroError) do
           t.call(empty_args)


### PR DESCRIPTION
Fixes

```console
Postinstall false | [ -f ../../sam.cr ] && cp -i examples/sam.template ../../sam.cr 2>/dev/null
Failed false | [ -f ../../sam.cr ] && cp -i examples/sam.template ../../sam.cr 2>/dev/null:
```