### PR TITLE
Add fallbacks if OS has no tput

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-env:
-  - TERM=xterm-256color
-before_script:
-  - crystal examples/sam.cr setup
-script: ./bin/ameba && crystal spec

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 dependencies:
   sam:
     github: imdrasil/sam.cr
-    version: 0.4.1
+    version: 0.4.2
 ```
 
 After executing `shards install` Sam-file will be added to the root of your project (unless you already have one).

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sam
-version: 0.4.1
+version: 0.4.2
 
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>

--- a/src/sam.cr
+++ b/src/sam.cr
@@ -3,6 +3,8 @@ require "./sam/*"
 module Sam
   extend Execution
 
+  VERSION = "0.4.2"
+
   # Task separation symbol used in command line.
   TASK_SEPARATOR = "@"
 

--- a/src/sam/shell_table.cr
+++ b/src/sam/shell_table.cr
@@ -8,7 +8,7 @@ module Sam
     getter tasks : Array(Task), width : Int32
 
     def initialize(@tasks)
-      @width = `tput cols`.to_i
+      @width = terminal_width
     end
 
     def generate
@@ -16,6 +16,26 @@ module Sam
         write_header(io)
         tasks.each { |task| write_task(io, task) }
       end
+    end
+
+    private def terminal_width
+      if has_tput?
+        `tput cols`.to_i
+      elsif has_stty?
+        `stty size`.chomp.split(' ')[1].to_i
+      else
+        80
+      end
+    end
+
+    private def has_tput?
+      !`which tput`.empty?
+    end
+
+    private def has_stty?
+      return false if `which stty`.empty?
+
+      /\d* \d*/.matches?(`stty size`)
     end
 
     private def write_header(io)
@@ -59,7 +79,7 @@ module Sam
         ].min.to_i.as(Int32)
     end
 
-    def description_column_width
+    private def description_column_width
       @description_column_width ||= (clean_width - name_column_width).as(Int32)
     end
 

--- a/src/sam/version.cr
+++ b/src/sam/version.cr
@@ -1,3 +1,0 @@
-module Sam
-  VERSION = "0.4.1"
-end


### PR DESCRIPTION
Fix #18 

#### Changes

* use `stty` if `tput` is missing or fallback to `80` if it is missing as well when calculate current terminal width