### PR TITLE
Set default interpreter for sam.cr to /usr/bin/env crystal

### DIFF
--- a/examples/sam.template
+++ b/examples/sam.template
@@ -1,4 +1,4 @@
-#!/bin/crystal
+#!/usr/bin/env crystal
 
 require "sam"
 


### PR DESCRIPTION
The current implementation makes assumptions about where someone will have crystal installed. See [this stackoverflow](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash) (and linked questions therein) for more background.

I think it would also make sense to have the user execute bit set on this file as part of the install, which would make it actually executable as `./sam.cr` by default.