### PR TITLE
fix: Postinstall script cannot be executed 

### DIFF
--- a/postinstall.cr
+++ b/postinstall.cr
@@ -2,5 +2,5 @@ sam_cr_path = "../../sam.cr"
 template_path = "examples/sam.template"
 
 if !File.exists?(sam_cr_path)
-  File.copy(template_path, sam_cr_path, preserve: true)
+  File.copy(template_path, sam_cr_path)
 end

--- a/postinstall.cr
+++ b/postinstall.cr
@@ -1,0 +1,6 @@
+sam_cr_path = "../../sam.cr"
+template_path = "examples/sam.template"
+
+if !File.exists?(sam_cr_path)
+  File.copy(template_path, sam_cr_path, preserve: true)
+end

--- a/shard.yml
+++ b/shard.yml
@@ -14,4 +14,4 @@ development_dependencies:
     version: "= 1.4.3"
 
 scripts:
-  postinstall: "if not exist ../../sam.cr copy /-y examples/sam.template ../../sam.cr >nul 2>&1"
+  postinstall: "crystal postinstall.cr"

--- a/shard.yml
+++ b/shard.yml
@@ -14,4 +14,4 @@ development_dependencies:
     version: "= 1.4.3"
 
 scripts:
-  postinstall: "false | [ -f ../../sam.cr ]  && true || cp -i examples/sam.template ../../sam.cr 2>/dev/null"
+  postinstall: "if not exist ..\..\sam.cr copy /-y examples\sam.template ..\..\sam.cr >nul 2>&1"

--- a/shard.yml
+++ b/shard.yml
@@ -14,4 +14,4 @@ development_dependencies:
     version: "= 1.4.3"
 
 scripts:
-  postinstall: "if not exist ..\..\sam.cr copy /-y examples\sam.template ..\..\sam.cr >nul 2>&1"
+  postinstall: "if not exist ../../sam.cr copy /-y examples/sam.template ../../sam.cr >nul 2>&1"


### PR DESCRIPTION
### Description

This pull request addresses the issue of Windows compatibility for the `postinstall` script in the `shard.yml` file. The original script was not supported on Windows, which caused installation issues for users on that platform.

### Changes Made

- Replaced the original `postinstall` script with a Crystal script to ensure compatibility across different operating systems, including Windows.

### New postinstall Script

The new script is as follows:

```crystal
sam_cr_path = "../../sam.cr"
template_path = "examples/sam.template"

if !File.exists?(sam_cr_path)
  File.copy(template_path, sam_cr_path)
end
```

### Benefits

- Ensures that the `postinstall` script runs smoothly on Windows.
- Leverages Crystal's standard library for file operations, making the script more portable and easier to maintain.

### Testing

- Verified that the `sam.cr` file is correctly copied from the template if it does not already exist.

### Related Issues

- #24

Thank you for considering this improvement. Looking forward to your feedback.