### PR TITLE
Fix: Disable `tput` and `stty` Check on Windows

### DIFF
--- a/src/sam/shell_table.cr
+++ b/src/sam/shell_table.cr
@@ -37,9 +37,13 @@ module Sam
     end
 
     private def has_stty?
-      return false if `which stty`.empty?
+      {% if flag?(:win32) %}
+        false
+      {% else %}
+        return false if `which stty`.empty?
 
-      /\d* \d*/.matches?(`stty size`)
+        /\d* \d*/.matches?(`stty size`)
+      {% end %}
     end
 
     private def write_header(io)

--- a/src/sam/shell_table.cr
+++ b/src/sam/shell_table.cr
@@ -29,7 +29,11 @@ module Sam
     end
 
     private def has_tput?
-      !`which tput`.empty?
+      {% if flag?(:win32) %}
+        false
+      {% else %}
+        !`which tput`.empty?
+      {% end %}
     end
 
     private def has_stty?


### PR DESCRIPTION
### Summary

This PR addresses an issue where the `tput` and `stty` command check is performed on Windows systems. Since `tput` and `stty` is not available on Windows, this check should be bypassed to prevent errors like this:

```
lib\sam\src\sam\shell_table.cr:32 in 'has_tput?'
lib\sam\src\sam\shell_table.cr:22 in 'terminal_width'
lib\sam\src\sam\shell_table.cr:11 in 'initialize'
lib\sam\src\sam\shell_table.cr:10 in 'new'
lib\sam\src\sam\tasks.cr:6 in '->'
lib\sam\src\sam\task.cr:56 in 'call'
lib\sam\src\sam\execution.cr:19 in 'invoke'
lib\sam\src\sam.cr:38 in 'invoke'
lib\sam\src\sam.cr:57 in 'process_tasks'
lib\sam\src\sam.cr:42 in 'help'
sam.cr:5 in '__crystal_main'
C:\Users\LOSSES Don\AppData\Local\Programs\Crystal\src\crystal\main.cr:129 in 'main_user_code'
C:\Users\LOSSES Don\AppData\Local\Programs\Crystal\src\crystal\main.cr:115 in 'main'
C:\Users\LOSSES Don\AppData\Local\Programs\Crystal\src\crystal\main.cr:141 in 'main'
C:\Users\LOSSES Don\AppData\Local\Programs\Crystal\src\crystal\system\win32\wmain.cr:37 in 'wmain'
D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288 in '__scrt_common_main_seh'
C:\Windows\System32\KERNEL32.DLL +75133 in 'BaseThreadInitThunk'
C:\Windows\SYSTEM32\ntdll.dll +371288 in 'RtlUserThreadStart'
Error executing process: 'which tput': The system cannot find the file specified.
```

### Changes

- Modified the `has_tput?` and `has_stty?` method to return `false` when running on Windows (`win32` flag).
- Retained the existing behavior for non-Windows systems.

### Rationale

The `tput` and `stty` command is used to manipulate terminal settings and is not available on Windows. Attempting to check for `tput` on Windows systems results in unnecessary errors. By adding a conditional check for the `win32` flag, we can ensure that the method returns `false` on Windows, thereby avoiding any issues related to the absence of `tput` or `stty`.

### Testing
- Verified that the `has_tput?` method returns `false` on Windows.
